### PR TITLE
feat: add get_edifact_format_version_valid_from()

### DIFF
--- a/src/_efoli_version.py
+++ b/src/_efoli_version.py
@@ -1,1 +1,0 @@
-version = "2.2.1.dev0+gf6abe3c4e.d20260403"

--- a/src/_efoli_version.py
+++ b/src/_efoli_version.py
@@ -1,0 +1,1 @@
+version = "2.2.1.dev0+gf6abe3c4e.d20260403"

--- a/src/efoli/__init__.py
+++ b/src/efoli/__init__.py
@@ -3,7 +3,12 @@ efoli contains enums and related helper functions for EDIFACT formats and format
 """
 
 from .edifact_format import EdifactFormat, get_format_of_pruefidentifikator
-from .edifact_format_version import EdifactFormatVersion, get_current_edifact_format_version, get_edifact_format_version
+from .edifact_format_version import (
+    EdifactFormatVersion,
+    get_current_edifact_format_version,
+    get_edifact_format_version,
+    get_edifact_format_version_valid_from,
+)
 
 __all__ = [
     "EdifactFormat",
@@ -11,4 +16,5 @@ __all__ = [
     "EdifactFormatVersion",
     "get_current_edifact_format_version",
     "get_edifact_format_version",
+    "get_edifact_format_version_valid_from",
 ]

--- a/src/efoli/edifact_format_version.py
+++ b/src/efoli/edifact_format_version.py
@@ -50,21 +50,29 @@ _format_version_thresholds: list[tuple[datetime.datetime, EdifactFormatVersion]]
 
 
 def _build_valid_from_map() -> dict[EdifactFormatVersion, datetime.date]:
-    """Derive start dates from the thresholds list.
+    """Derive inclusive start dates from the thresholds list.
 
     Each threshold is the exclusive upper bound of a version — meaning the NEXT version
-    starts at that threshold. Converting to Europe/Berlin gives the local start date.
+    starts at that threshold. Converting to Europe/Berlin gives the local inclusive start date.
     """
+    # Ensure thresholds are sorted by datetime (guard against accidental reordering)
+    sorted_thresholds = sorted(_format_version_thresholds, key=lambda t: t[0])
     result: dict[EdifactFormatVersion, datetime.date] = {}
-    versions_in_order = [v for _, v in _format_version_thresholds]
+    versions_in_order = [v for _, v in sorted_thresholds]
     # For each threshold at index i, the version at index i+1 starts at that threshold
-    for i, (threshold_dt, _) in enumerate(_format_version_thresholds):
+    for i, (threshold_dt, _) in enumerate(sorted_thresholds):
         if i + 1 < len(versions_in_order):
             next_version = versions_in_order[i + 1]
             result[next_version] = threshold_dt.astimezone(_berlin).date()
-    # Last version in thresholds list: its end threshold is the start of the fallback version (FV2610)
-    last_threshold = _format_version_thresholds[-1][0]
-    result[EdifactFormatVersion.FV2610] = last_threshold.astimezone(_berlin).date()
+    # Last version in thresholds list: its end threshold is the start of the fallback version
+    last_threshold = sorted_thresholds[-1][0]
+    last_version_in_thresholds = sorted_thresholds[-1][1]
+    # The fallback version is the one AFTER the last in the thresholds list
+    all_fvs = list(EdifactFormatVersion)
+    last_idx = all_fvs.index(last_version_in_thresholds)
+    if last_idx + 1 < len(all_fvs):
+        fallback_version = all_fvs[last_idx + 1]
+        result[fallback_version] = last_threshold.astimezone(_berlin).date()
     return result
 
 

--- a/src/efoli/edifact_format_version.py
+++ b/src/efoli/edifact_format_version.py
@@ -8,6 +8,7 @@ import pytz
 from .strenum import StrEnum
 
 _berlin = pytz.timezone("Europe/Berlin")
+_utc = datetime.timezone.utc
 
 
 class EdifactFormatVersion(StrEnum):
@@ -32,6 +33,60 @@ class EdifactFormatVersion(StrEnum):
         return self.value
 
 
+# Maps the exclusive upper threshold (UTC) to the version valid until that threshold.
+# When adding a new FV, append a new entry here AND update the fallback in get_edifact_format_version.
+_format_version_thresholds: list[tuple[datetime.datetime, EdifactFormatVersion]] = [
+    (datetime.datetime(2021, 9, 30, 22, 0, 0, 0, tzinfo=_utc), EdifactFormatVersion.FV2104),
+    (datetime.datetime(2022, 9, 30, 22, 0, 0, 0, tzinfo=_utc), EdifactFormatVersion.FV2110),
+    (datetime.datetime(2023, 3, 31, 22, 0, 0, 0, tzinfo=_utc), EdifactFormatVersion.FV2210),
+    (datetime.datetime(2023, 9, 30, 22, 0, 0, 0, tzinfo=_utc), EdifactFormatVersion.FV2304),
+    (datetime.datetime(2024, 4, 2, 22, 0, 0, 0, tzinfo=_utc), EdifactFormatVersion.FV2310),
+    (datetime.datetime(2024, 9, 30, 22, 0, 0, 0, tzinfo=_utc), EdifactFormatVersion.FV2404),
+    (datetime.datetime(2025, 6, 5, 22, 0, 0, 0, tzinfo=_utc), EdifactFormatVersion.FV2410),
+    (datetime.datetime(2025, 9, 30, 22, 0, 0, 0, tzinfo=_utc), EdifactFormatVersion.FV2504),
+    (datetime.datetime(2026, 3, 31, 22, 0, 0, 0, tzinfo=_utc), EdifactFormatVersion.FV2510),
+    (datetime.datetime(2026, 9, 30, 22, 0, 0, 0, tzinfo=_utc), EdifactFormatVersion.FV2604),
+]
+
+
+def _build_valid_from_map() -> dict[EdifactFormatVersion, datetime.date]:
+    """Derive start dates from the thresholds list.
+
+    Each threshold is the exclusive upper bound of a version — meaning the NEXT version
+    starts at that threshold. Converting to Europe/Berlin gives the local start date.
+    """
+    result: dict[EdifactFormatVersion, datetime.date] = {}
+    versions_in_order = [v for _, v in _format_version_thresholds]
+    # For each threshold at index i, the version at index i+1 starts at that threshold
+    for i, (threshold_dt, _) in enumerate(_format_version_thresholds):
+        if i + 1 < len(versions_in_order):
+            next_version = versions_in_order[i + 1]
+            result[next_version] = threshold_dt.astimezone(_berlin).date()
+    # Last version in thresholds list: its end threshold is the start of the fallback version (FV2610)
+    last_threshold = _format_version_thresholds[-1][0]
+    result[EdifactFormatVersion.FV2610] = last_threshold.astimezone(_berlin).date()
+    return result
+
+
+_valid_from_map = _build_valid_from_map()
+
+
+def get_edifact_format_version_valid_from(version: EdifactFormatVersion) -> datetime.date:
+    """
+    Returns the date from which a format version is valid (in Europe/Berlin timezone).
+
+    :param version: The format version to look up.
+    :return: The first day on which this format version is active.
+    :raises KeyError: If the start date is not known (only FV2104, the earliest version).
+    """
+    if version not in _valid_from_map:
+        raise KeyError(
+            f"Start date for {version} is not known. "
+            f"Known versions: {', '.join(str(v) for v in sorted(_valid_from_map.keys(), key=lambda x: x.value))}"
+        )
+    return _valid_from_map[version]
+
+
 def get_edifact_format_version(key_date: Union[datetime.datetime, datetime.date]) -> EdifactFormatVersion:
     """
     Retrieves the appropriate Edifact format version applicable for the given key date.
@@ -45,22 +100,8 @@ def get_edifact_format_version(key_date: Union[datetime.datetime, datetime.date]
     """
     if not isinstance(key_date, datetime.datetime) and isinstance(key_date, datetime.date):
         key_date = _berlin.localize(datetime.datetime.combine(key_date, datetime.time(0, 0, 0, 0)))
-    format_version_thresholds: list[tuple[datetime.datetime, EdifactFormatVersion]] = (
-        [  # maps the exclusive upper threshold to the version valid until that threshold
-            (datetime.datetime(2021, 9, 30, 22, 0, 0, 0, tzinfo=datetime.timezone.utc), EdifactFormatVersion.FV2104),
-            (datetime.datetime(2022, 9, 30, 22, 0, 0, 0, tzinfo=datetime.timezone.utc), EdifactFormatVersion.FV2110),
-            (datetime.datetime(2023, 3, 31, 22, 0, 0, 0, tzinfo=datetime.timezone.utc), EdifactFormatVersion.FV2210),
-            (datetime.datetime(2023, 9, 30, 22, 0, 0, 0, tzinfo=datetime.timezone.utc), EdifactFormatVersion.FV2304),
-            (datetime.datetime(2024, 4, 2, 22, 0, 0, 0, tzinfo=datetime.timezone.utc), EdifactFormatVersion.FV2310),
-            (datetime.datetime(2024, 9, 30, 22, 0, 0, 0, tzinfo=datetime.timezone.utc), EdifactFormatVersion.FV2404),
-            (datetime.datetime(2025, 6, 5, 22, 0, 0, 0, tzinfo=datetime.timezone.utc), EdifactFormatVersion.FV2410),
-            (datetime.datetime(2025, 9, 30, 22, 0, 0, 0, tzinfo=datetime.timezone.utc), EdifactFormatVersion.FV2504),
-            (datetime.datetime(2026, 3, 31, 22, 0, 0, 0, tzinfo=datetime.timezone.utc), EdifactFormatVersion.FV2510),
-            (datetime.datetime(2026, 9, 30, 22, 0, 0, 0, tzinfo=datetime.timezone.utc), EdifactFormatVersion.FV2604),
-        ]
-    )
 
-    for threshold_date, version in format_version_thresholds:
+    for threshold_date, version in _format_version_thresholds:
         if key_date < threshold_date:
             return version
 

--- a/unittests/test_edifact_format_version.py
+++ b/unittests/test_edifact_format_version.py
@@ -2,7 +2,12 @@ from datetime import date, datetime, timezone
 
 import pytest
 
-from efoli import EdifactFormatVersion, get_current_edifact_format_version, get_edifact_format_version
+from efoli import (
+    EdifactFormatVersion,
+    get_current_edifact_format_version,
+    get_edifact_format_version,
+    get_edifact_format_version_valid_from,
+)
 
 
 @pytest.mark.parametrize(
@@ -59,3 +64,28 @@ def test_get_current_format_version() -> None:
 
 def test_str_representation() -> None:
     assert str(EdifactFormatVersion.FV2504) == "FV2504"
+
+
+@pytest.mark.parametrize(
+    "version,expected_date",
+    [
+        pytest.param(EdifactFormatVersion.FV2110, date(2021, 10, 1), id="FV2110"),
+        pytest.param(EdifactFormatVersion.FV2210, date(2022, 10, 1), id="FV2210"),
+        pytest.param(EdifactFormatVersion.FV2304, date(2023, 4, 1), id="FV2304"),
+        pytest.param(EdifactFormatVersion.FV2310, date(2023, 10, 1), id="FV2310"),
+        pytest.param(EdifactFormatVersion.FV2404, date(2024, 4, 3), id="FV2404"),
+        pytest.param(EdifactFormatVersion.FV2410, date(2024, 10, 1), id="FV2410"),
+        pytest.param(EdifactFormatVersion.FV2504, date(2025, 6, 6), id="FV2504"),
+        pytest.param(EdifactFormatVersion.FV2510, date(2025, 10, 1), id="FV2510"),
+        pytest.param(EdifactFormatVersion.FV2604, date(2026, 4, 1), id="FV2604"),
+        pytest.param(EdifactFormatVersion.FV2610, date(2026, 10, 1), id="FV2610"),
+    ],
+)
+def test_format_version_valid_from(version: EdifactFormatVersion, expected_date: date) -> None:
+    actual = get_edifact_format_version_valid_from(version)
+    assert actual == expected_date
+
+
+def test_format_version_valid_from_unknown_raises() -> None:
+    with pytest.raises(KeyError):
+        get_edifact_format_version_valid_from(EdifactFormatVersion.FV2104)

--- a/unittests/test_edifact_format_version.py
+++ b/unittests/test_edifact_format_version.py
@@ -89,3 +89,16 @@ def test_format_version_valid_from(version: EdifactFormatVersion, expected_date:
 def test_format_version_valid_from_unknown_raises() -> None:
     with pytest.raises(KeyError):
         get_edifact_format_version_valid_from(EdifactFormatVersion.FV2104)
+
+
+def test_all_format_versions_except_first_have_valid_from() -> None:
+    """Every FV except the very first (FV2104) must have a known start date.
+    This test fails if a new FV is added to the enum but not to the thresholds list."""
+    all_fvs = list(EdifactFormatVersion)
+    first_fv = all_fvs[0]
+    for fv in all_fvs[1:]:
+        result = get_edifact_format_version_valid_from(fv)
+        assert isinstance(result, date), f"{fv} should have a valid_from date"
+    # First FV has no start date
+    with pytest.raises(KeyError):
+        get_edifact_format_version_valid_from(first_fv)


### PR DESCRIPTION
## Summary

- Neue Funktion `get_edifact_format_version_valid_from(fv) -> date` — gibt das Startdatum einer Formatversion zurück (Europe/Berlin)
- Leitet die Startdaten aus den bestehenden `format_version_thresholds` ab — keine Datenduplizierung
- Thresholds auf Modul-Ebene extrahiert für Wiederverwendung

## Motivation

In mcp-bdew-mako (Hochfrequenz/mcp-bdew-mako#96) wurde die gleiche Information durch Tag-für-Tag-Probing von `get_edifact_format_version()` ermittelt — unnötig wenn die Daten hier schon vorliegen.

## Test plan

- [x] 12 neue Tests: Startdaten für FV2110–FV2610, KeyError für FV2104
- [x] Alle 38 Tests grün (bestehende unverändert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)